### PR TITLE
Fix for HK 1.5 Unity upgrade + Unload bug fix

### DIFF
--- a/CompassAlwaysOn/CompassAlwaysOn.cs
+++ b/CompassAlwaysOn/CompassAlwaysOn.cs
@@ -160,7 +160,7 @@ namespace CompassAlwaysOn
         {
             IL.GameMap.PositionCompass -= ModifyCompassBool;
             IL.GameMap.WorldMap -= ModifyCompassBool;
-            On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.OnEnter += ShowOnWorldMap;
+            On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.OnEnter -= ShowOnWorldMap;
 
             foreach (ILHook hook in ModInteropHooks)
             {

--- a/CompassAlwaysOn/CompassAlwaysOn.csproj
+++ b/CompassAlwaysOn/CompassAlwaysOn.csproj
@@ -4,52 +4,48 @@
     <TargetFramework>net472</TargetFramework>
     <RootNamespace>CompassAlwaysOn</RootNamespace>
     <AssemblyTitle>CompassAlwaysOn</AssemblyTitle>
-    <AssemblyVersion>1.5.1.0</AssemblyVersion>
+    <AssemblyVersion>1.2.1</AssemblyVersion>
     <Deterministic>true</Deterministic>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
-    <HollowKnightRefs>../API</HollowKnightRefs>
-    <ExportDir>bin/Publish</ExportDir>
+    <HollowKnightRefs>..\API</HollowKnightRefs>
+    <ExportDir>bin\Publish</ExportDir>
   </PropertyGroup>
   
   <!--Gitignored local build properties file to modify the HollowKnightRefs value without needing to change anything in the remote.-->
   <Import Project="LocalBuildProperties.props" Condition="Exists('LocalBuildProperties.props')" />
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(HollowKnightRefs)/Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>$(HollowKnightRefs)/MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_PlayMaker">
-      <HintPath>$(HollowKnightRefs)/MMHOOK_PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MMHOOK_PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
-      <HintPath>$(HollowKnightRefs)/Mono.Cecil.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.RuntimeDetour, Version=21.4.29.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(HollowKnightRefs)/MonoMod.RuntimeDetour.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.Utils">
-      <HintPath>$(HollowKnightRefs)/MonoMod.Utils.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
-      <HintPath>$(HollowKnightRefs)/PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>$(HollowKnightRefs)/UnityEngine.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(HollowKnightRefs)/UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   
@@ -60,7 +56,7 @@
   </Target>
   
   <Target Name="CopyMod" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb" DestinationFolder="$(HollowKnightRefs)/Mods/$(TargetName)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb" DestinationFolder="$(HollowKnightRefs)\Mods\$(TargetName)" SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="CreateReleaseZip" AfterTargets="PostBuildEvent" Condition="'$(Configuration)' == 'Release'">

--- a/CompassAlwaysOn/CompassAlwaysOn.csproj
+++ b/CompassAlwaysOn/CompassAlwaysOn.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <RootNamespace>CompassAlwaysOn</RootNamespace>
     <AssemblyTitle>CompassAlwaysOn</AssemblyTitle>
-    <AssemblyVersion>1.2.1</AssemblyVersion>
+    <AssemblyVersion>1.5.1.0</AssemblyVersion>
     <Deterministic>true</Deterministic>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>latest</LangVersion>
@@ -24,7 +24,7 @@
   
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(HollowKnightRefs)/Assembly-CSharp.dll.m</HintPath>
+      <HintPath>$(HollowKnightRefs)/Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
       <HintPath>$(HollowKnightRefs)/MMHOOK_Assembly-CSharp.dll</HintPath>

--- a/CompassAlwaysOn/CompassAlwaysOn.csproj
+++ b/CompassAlwaysOn/CompassAlwaysOn.csproj
@@ -11,41 +11,45 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <HollowKnightRefs>..\API</HollowKnightRefs>
-    <ExportDir>bin\Publish</ExportDir>
+    <HollowKnightRefs>../API</HollowKnightRefs>
+    <ExportDir>bin/Publish</ExportDir>
   </PropertyGroup>
   
   <!--Gitignored local build properties file to modify the HollowKnightRefs value without needing to change anything in the remote.-->
   <Import Project="LocalBuildProperties.props" Condition="Exists('LocalBuildProperties.props')" />
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(HollowKnightRefs)\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Assembly-CSharp.dll.m</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>$(HollowKnightRefs)\MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_PlayMaker">
-      <HintPath>$(HollowKnightRefs)\MMHOOK_PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/MMHOOK_PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
-      <HintPath>$(HollowKnightRefs)\Mono.Cecil.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.RuntimeDetour, Version=21.4.29.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(HollowKnightRefs)\MonoMod.RuntimeDetour.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.Utils">
-      <HintPath>$(HollowKnightRefs)\MonoMod.Utils.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
-      <HintPath>$(HollowKnightRefs)\PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>$(HollowKnightRefs)\UnityEngine.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(HollowKnightRefs)\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   
@@ -56,7 +60,7 @@
   </Target>
   
   <Target Name="CopyMod" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb" DestinationFolder="$(HollowKnightRefs)\Mods\$(TargetName)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb" DestinationFolder="$(HollowKnightRefs)/Mods/$(TargetName)" SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="CreateReleaseZip" AfterTargets="PostBuildEvent" Condition="'$(Configuration)' == 'Release'">


### PR DESCRIPTION
## Summary
- Fixes the mod for Hollow Knight 1.5.78.11833 (Unity 6 upgrade)
- Fixes a bug in `Unload()` where `+=` was used instead of `-=` for the `ShowOnWorldMap` PlayMaker hook
- Cross-platform build support (forward slashes in paths, added Microsoft.NETFramework.ReferenceAssemblies NuGet)
- Version bump to 1.5.1.0

## Changes
- **CompassAlwaysOn.cs**: Fixed `Unload()` — was re-adding `ShowOnWorldMap` hook instead of removing it
- **CompassAlwaysOn.csproj**: Fixed `Assembly-CSharp.dll.m` typo, version bump, cross-platform paths

## Compatibility
- Hollow Knight 1.5.78.11833
- Modding API v77

## Test plan
- [x] Verified mod loads successfully with API v77
- [x] Tested on macOS (requires Rosetta for Apple Silicon due to MonoMod W^X limitation)
- [x] Compass icon visible on map without Wayward Compass equipped